### PR TITLE
Fix App test and add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+build/
+.env

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,14 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+// Mock the authentication hook to avoid Firebase dependency during tests
+jest.mock('./hooks/useAuth', () => ({
+  useAuth: () => ({ user: null, loading: false })
+}));
+
+test('shows authentication screen when user is not logged in', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Tahaveli Unified/i);
+  expect(heading).toBeInTheDocument();
 });
+


### PR DESCRIPTION
## Summary
- mock `useAuth` in `App.test` to avoid Firebase dependency
- add `.gitignore` for node_modules and build artifacts

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68984afc4c148322bfcb10b12ea0c390