### PR TITLE
Add example tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test -- --watchAll=false

--- a/src/components/AuthScreen.test.tsx
+++ b/src/components/AuthScreen.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import AuthScreen from './AuthScreen';
+
+jest.mock('../firebase/config', () => ({ auth: {} }));
+
+jest.mock('firebase/auth', () => ({
+  signInWithEmailAndPassword: jest.fn(),
+  createUserWithEmailAndPassword: jest.fn(),
+}));
+
+describe('AuthScreen', () => {
+  it('renders login form by default', () => {
+    render(<AuthScreen />);
+    expect(
+      screen.getByRole('heading', { name: /tahaveli unified/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /giriş yap/i })).toBeInTheDocument();
+  });
+
+  it('toggles to register form when Kayıt Ol is clicked', () => {
+    render(<AuthScreen />);
+    fireEvent.click(screen.getByRole('button', { name: /kayıt ol/i }));
+    expect(
+      screen.getByRole('heading', { name: /kayıt ol/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -1,0 +1,29 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAuth } from './useAuth';
+
+jest.mock('../firebase/config', () => ({ auth: {} }));
+
+const mockOnAuthStateChanged = jest.fn();
+
+jest.mock('firebase/auth', () => ({
+  onAuthStateChanged: (...args) => mockOnAuthStateChanged(...args),
+}));
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    mockOnAuthStateChanged.mockReset();
+  });
+
+  it('updates user and loading state after auth change', async () => {
+    const mockUser = { uid: '123' } as any;
+    mockOnAuthStateChanged.mockImplementation((auth, next) => {
+      next(mockUser);
+      return () => {};
+    });
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.user).toEqual(mockUser);
+  });
+});


### PR DESCRIPTION
## Summary
- add example tests for useAuth hook and AuthScreen component
- run tests in GitHub Actions CI

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6898503f594c8322a52e9c3813ce690f